### PR TITLE
Add lzma to apt-get list

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -27,6 +27,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
     libgoogle-perftools-dev \
     libjansson-dev \
     librdf-dev \
+    liblzma-dev \
     jq \
     bc \
     rs \


### PR DESCRIPTION
Our Jenkin's builds are failing because our base image didn't have lzma, which the new htslib requests. This appears to fix it.